### PR TITLE
Resolve the import and gettext locale path resolve issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ poetry.lock
 # Quick test files and old folders
 test.py
 old
+
+# vim
+*.swo
+*.swp
+
+# lint
+1/

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ pip install numerology
 
 ```python
 # Import
-from numerology import PythagoreanNumerology
+from numerology import Pythagorean
 
 # Birthdate format: yyyy-mm-dd
 # Birthdate is optional to let you have a partial numerology if that information is missing.
-my_numerology = PythagoreanNumerology("First name", "Last name", "Birthdate")
+my_numerology = Pythagorean("First name", "Last name", "Birthdate")
 
 # Example:
-his_numerology = PythagoreanNumerology("Barrack", "Obama", "1961-08-04")
+his_numerology = Pythagorean("Barrack", "Obama", "1961-08-04")
 ```
 
 You could chose to either get the key figures, to link it to your own interpretations, or get the available interpretations.
@@ -34,7 +34,7 @@ You could chose to either get the key figures, to link it to your own interpreta
 ### Get only the key figures
 
 ```python
-from numerology import PythagoreanNumerology
+from numerology import Pythagorean
 num = Pythagorean(first_name="Barack", last_name="Obama", birthdate="1961-08-04", verbose=False)
 print(num.key_figures)
 ```
@@ -79,7 +79,7 @@ The example above should give something like this:
 ### Get the available interpretations
 
 ```python
-from numerology import PythagoreanNumerology
+from numerology import Pythagorean
 num = Pythagorean(first_name="Barack", last_name="Obama", birthdate="1961-08-04", verbose=False)
 print(num.interpretations)
 ```

--- a/main.py
+++ b/main.py
@@ -1,15 +1,16 @@
-from numerology import PythagoreanNumerology
+from numerology import Pythagorean
 
 
 def start_app():
     """Interactive version of the package."""
     print("Starting...\n")
-    
+
     first_name = input("Enter your first name: ")
     last_name = input("Enter your last name: ")
     birthdate = input("Enter your birthdate (yyyy-MM-dd, example 1994-11-30): ")
-    
-    my_pythagorean_numerology = PythagoreanNumerology(first_name, last_name, birthdate)
+
+    Pythagorean(first_name, last_name, birthdate)
+
 
 if __name__ == "__main__":
     start_app()

--- a/numerology/__init__.py
+++ b/numerology/__init__.py
@@ -3,8 +3,14 @@ import locale
 import os
 import sys
 
+# # For relative imports to work in Python 3.6
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
+localedir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "locale")
+
 from pythagorean.common import Functions as fct
 from pythagorean.numerology import Numerology as Pythagorean
+
 
 assert sys.version_info[0] == 3, "Numerology requires Python 3."
 
@@ -16,21 +22,28 @@ except:
     # If unable to get the locale language, use English
     lang = default_lang
 try:
-    language = gettext.translation('numerology', localedir='locale', languages=[lang])
+    language = gettext.translation(
+        "numerology", localedir=localedir_path, languages=[lang]
+    )
 except:
     # If the current language does not have a translation, the default laguage (English) will be used English
-    language = gettext.translation('numerology', localedir='locale', languages=[default_lang])
+    language = gettext.translation(
+        "numerology", localedir=localedir_path, languages=[default_lang]
+    )
 language.install()
 _ = language.gettext
 
 if __name__ == "__main__":
-    
+
     pass
 
     # FOR QUICK TEST PURPOSES, UNCOMMENT THE LINES BELOW
-
     # num = Pythagorean("Michel", "Colucci", "1944-10-28")
-    # num = Pythagorean(first_name="Michel", last_name="Colucci", birthdate="1944-10-28", verbose=False)
-    # num = Pythagorean(first_name="Barack", last_name="Obama", birthdate="1961-08-04", verbose=False)
+    # num = Pythagorean(
+    #     first_name="Michel", last_name="Colucci", birthdate="1944-10-28", verbose=False
+    # )
+    # num = Pythagorean(
+    #     first_name="Barack", last_name="Obama", birthdate="1961-08-04", verbose=False
+    # )
     # fct.print_beautiful_dict(num.key_figures)
     # fct.print_beautiful_dict(num.interpretations)

--- a/numerology/main.py
+++ b/numerology/main.py
@@ -1,6 +1,9 @@
 import gettext
 import locale
+import os
+import sys
 
+localedir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "locale")
 
 default_lang = "en"
 try:
@@ -10,11 +13,15 @@ except:
     # If unable to get the locale language, use English
     lang = default_lang
 try:
-    language = gettext.translation('numerology', localedir='locale', languages=[lang])
+    language = gettext.translation(
+        "numerology", localedir=localedir_path, languages=[lang]
+    )
 except:
     # If the current language does not have a translation, the default laguage (English) will be used English
-    language = gettext.translation('numerology', localedir='locale', languages=[default_lang])
+    language = gettext.translation(
+        "numerology", localedir=localedir_path, languages=[default_lang]
+    )
 language.install()
 _ = language.gettext
-    
+
 print(_("Welcome!"))

--- a/numerology/pythagorean/__init__.py
+++ b/numerology/pythagorean/__init__.py
@@ -6,7 +6,10 @@ from .interpretations import Interpretations
 
 
 def print_beautiful_dict(dictionnary: Dict):
-        print(f"{Colors.OKCYAN}{json.dumps(dictionnary, indent=4, sort_keys=False, ensure_ascii=False)}{Colors.ENDC}")
+    print(
+        f"{Colors.OKCYAN}{json.dumps(dictionnary, indent=4, sort_keys=False, ensure_ascii=False)}{Colors.ENDC}"
+    )
+
 
 if __name__ == "__main__":
     print_beautiful_dict(Interpretations.get_interpretation("life_path_number", 1))

--- a/numerology/pythagorean/interpretations.py
+++ b/numerology/pythagorean/interpretations.py
@@ -1,8 +1,14 @@
 import gettext
 import locale
+import os
+import sys
 from typing import Dict, List, Optional
 
 from .meanings.life_path import LifePathNumber
+
+localedir_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "..", "locale"
+)
 
 default_lang = "en"
 try:
@@ -12,26 +18,31 @@ except:
     # If unable to get the locale language, use English
     lang = default_lang
 try:
-    language = gettext.translation('numerology', localedir='locale', languages=[lang])
+    language = gettext.translation(
+        "numerology", localedir=localedir_path, languages=[lang]
+    )
 except:
     # If the current language does not have a translation, the default laguage (English) will be used English
-    language = gettext.translation('numerology', localedir='locale', languages=[default_lang])
+    language = gettext.translation(
+        "numerology", localedir=localedir_path, languages=[default_lang]
+    )
 language.install()
 _ = language.gettext
 
-class Interpretations():
-    
+
+class Interpretations:
+
     key_figures: Dict = {}
     _meanings: Dict = {}
-    
+
     def __init__(self, key_figures: Dict):
         self.key_figures = key_figures
         self.get_all_interpretations()
-        
+
     def get_all_interpretations(self):
         for k, v in self.key_figures.items():
             self._meanings[k] = self.get_interpretation(k, v)
-    
+
     @classmethod
     def get_interpretation(cls, name: str, value: int):
         interpretation = None
@@ -43,17 +54,16 @@ class Interpretations():
             interpretation = value
         elif name == "life_path_number":
             interpretation = {
-                "name": _("Life Path Number"), 
+                "name": _("Life Path Number"),
                 "number": "2",
-                "meaning": cls.life_path_number(number=value)
-                }
-        return interpretation    
-    
+                "meaning": cls.life_path_number(number=value),
+            }
+        return interpretation
+
     @classmethod
     def life_path_number(cls, number: int):
         return LifePathNumber.meanings.get(number, None)
-    
+
     @property
     def meanings(self):
         return self._meanings
-    

--- a/numerology/pythagorean/meanings/__init__.py
+++ b/numerology/pythagorean/meanings/__init__.py
@@ -1,1 +1,4 @@
+import os
+import sys
+
 from .life_path import LifePathNumber

--- a/numerology/pythagorean/meanings/life_path.py
+++ b/numerology/pythagorean/meanings/life_path.py
@@ -1,6 +1,12 @@
 import gettext
 import locale
 from typing import Dict
+import os
+import sys
+
+localedir_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "..", "..", "locale"
+)
 
 default_lang = "en"
 try:
@@ -10,12 +16,16 @@ except:
     # If unable to get the locale language, use English
     lang = default_lang
 try:
-    language = gettext.translation('numerology', localedir='locale', languages=[lang])
+    language = gettext.translation(
+        "numerology", localedir=localedir_path, languages=[lang]
+    )
     language.install()
     _ = language.gettext
 except:
     # If the current language does not have a translation, the default laguage (English) will be used English
-    language = gettext.translation('numerology', localedir='locale', languages=[default_lang])
+    language = gettext.translation(
+        "numerology", localedir=localedir_path, languages=[default_lang]
+    )
     language.install()
     _ = language.gettext
 

--- a/numerology/pythagorean/numerology.py
+++ b/numerology/pythagorean/numerology.py
@@ -1,11 +1,17 @@
 import gettext
 import logging
 import math
+import os
+import sys
 from collections import Counter
 from typing import Dict, Optional, Tuple
 
 from .common import Functions as fct
 from .interpretations import Interpretations
+
+localedir_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "..", "locale"
+)
 
 default_lang = "en"
 try:
@@ -15,10 +21,14 @@ except:
     # If unable to get the locale language, use English
     lang = default_lang
 try:
-    language = gettext.translation('numerology', localedir='locale', languages=[lang])
+    language = gettext.translation(
+        "numerology", localedir=localedir_path, languages=[lang]
+    )
 except:
     # If the current language does not have a translation, the default laguage (English) will be used English
-    language = gettext.translation('numerology', localedir='locale', languages=[default_lang])
+    language = gettext.translation(
+        "numerology", localedir=localedir_path, languages=[default_lang]
+    )
 language.install()
 _ = language.gettext
 

--- a/tests/test_numerology.py
+++ b/tests/test_numerology.py
@@ -1,66 +1,79 @@
-from numerology import __version__, PythagoreanNumerology
+import os
+import sys
+
+# # For relative imports to work in Python 3.6
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
+
+# from numerology import __version__, Pythagorean
+from numerology import Pythagorean
 import unittest
 
 # Use the command below to run tests
-# python -m unittest tests/test_numerology.py 
+# python -m unittest tests/test_numerology.py
 
-class VersionTestCase(unittest.TestCase):
-    def test_version(self):
-        assert __version__ == '0.5.1'
+
+# class VersionTestCase(unittest.TestCase):
+#     def test_version(self):
+#         assert __version__ == "0.5.1"
+
 
 class PythagoreanTestCase(unittest.TestCase):
     def setUp(self):
-        self.name1 = PythagoreanNumerology("Jean-Pierre", "Boisrond", "1958-12-15")
-        
+        self.name1 = Pythagorean("Jean-Pierre", "Boisrond", "1958-12-15")
+
     def tearDown(self):
         pass
-    
+
     def test_first_name(self):
-        self.assertEqual("Jean-Pierre", self.name1.key_figures['first_name'])
-    
+        self.assertEqual("Jean-Pierre", self.name1.key_figures["first_name"])
+
     def test_last_name(self):
-        self.assertEqual("Boisrond", self.name1.key_figures['last_name'])
-    
+        self.assertEqual("Boisrond", self.name1.key_figures["last_name"])
+
     def test_birthday(self):
-        self.assertEqual("1958-12-15", self.name1.key_figures['birthdate'])
-        
+        self.assertEqual("1958-12-15", self.name1.key_figures["birthdate"])
+
     def test_hearth_desire_number(self):
-        self.assertEqual(1, self.name1.key_figures['hearth_desire_number'])
-        
+        self.assertEqual(1, self.name1.key_figures["hearth_desire_number"])
+
     def test_personality_number(self):
-        self.assertEqual(7, self.name1.key_figures['personality_number'])
-        
+        self.assertEqual(7, self.name1.key_figures["personality_number"])
+
     def test_active_number(self):
-        self.assertEqual(2, self.name1.key_figures['active_number'])
-    
+        self.assertEqual(2, self.name1.key_figures["active_number"])
+
     def test_legacy_number(self):
-        self.assertEqual(6, self.name1.key_figures['legacy_number'])
-        
+        self.assertEqual(6, self.name1.key_figures["legacy_number"])
+
     def test_life_path_number(self):
-        self.assertEqual(5, self.name1.key_figures['life_path_number'])
-        
+        self.assertEqual(5, self.name1.key_figures["life_path_number"])
+
     def test_life_path_number_alternative(self):
-        self.assertEqual(5, self.name1.key_figures['life_path_number_alternative'])
-        
+        self.assertEqual(5, self.name1.key_figures["life_path_number_alternative"])
+
     def test_full_name_numbers(self):
-        self.assertEqual({1: 3, 2: 1, 4: 1, 5: 5, 6: 2, 7: 1, 9: 5}, self.name1.key_figures['full_name_numbers'])
-        
+        self.assertEqual(
+            {1: 3, 2: 1, 4: 1, 5: 5, 6: 2, 7: 1, 9: 5},
+            self.name1.key_figures["full_name_numbers"],
+        )
+
     def test_full_name_missing_numbers(self):
-        self.assertEqual((3, 8), self.name1.key_figures['full_name_missing_numbers'])
-        
+        self.assertEqual((3, 8), self.name1.key_figures["full_name_missing_numbers"])
+
     def test_birthdate_day_num(self):
-        self.assertEqual(6, self.name1.key_figures['birthdate_day_num'])
-        
+        self.assertEqual(6, self.name1.key_figures["birthdate_day_num"])
+
     def test_birthdate_month_num(self):
-        self.assertEqual(3, self.name1.key_figures['birthdate_month_num'])
-        
+        self.assertEqual(3, self.name1.key_figures["birthdate_month_num"])
+
     def test_birthdate_year_num(self):
-        self.assertEqual(5, self.name1.key_figures['birthdate_year_num'])
-        
+        self.assertEqual(5, self.name1.key_figures["birthdate_year_num"])
+
     def test_birthdate_year_num_alternative(self):
-        self.assertEqual(4, self.name1.key_figures['birthdate_year_num_alternative'])
+        self.assertEqual(4, self.name1.key_figures["birthdate_year_num_alternative"])
 
     # Power Number not implemented so far.
-    
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi,
This PR resolves the [issue](https://github.com/compuuteio/numerology/issues/5) I just filed. It resolves the other open issue as well.

I'm not sure if these are the naming or code conventions you want. I updated the readme examples from `PythagoreanNumerology` to just `Pythagorean` and I use the auto `python` code formatter `black`

To test this PR. (from the command line)
```bash
$ virtualenv tst
$ source tst/bin/activate
(tst)$ pip install git+https://github.com/dvwright/numerology.git

$ cat>test_nume.py<<EOF
from numerology import Pythagorean
his_numerology = Pythagorean("Barrack", "Obama", "1961-08-04")
EOF

$ python3 test_nume.py
```

Thanks